### PR TITLE
Added a fix for an issue where certain binaries will timeout due to rpyc or DragodisError timeouts.

### DIFF
--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -210,11 +210,10 @@ class IDARemoteDisassembler(IDADisassembler):
             )
         self._script_path = ida_server.__file__
         self._rpyc_config = dict(self._rpyc_config)
-        if timeout <= 0:
+        if timeout is None or timeout <= 0:
             #Treat zero timeouts or -1 timeouts as infinite.
-            self._rpyc_config["sync_request_timeout"] = None
-        else:
-            self._rpyc_config["sync_request_timeout"] = timeout
+            timeout = None
+        self._rpyc_config["sync_request_timeout"] = timeout
 
         # Determine if 64 bit.
         if is_64_bit is None:

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -518,11 +518,11 @@ class IDARemoteDisassembler(IDADisassembler):
     def analyze(self) -> None:
         """
         Instruct IDA to initiate and wait for auto analysis completion.
-        NOTE: This function is likely subject to the timeout value provided in the IDARemoteDisassembler constructor.
         """
         logger.debug('Running autoanalysis.')
         self._idc.set_flag(self._idc.INF_GENFLAGS, self._idc.INFFL_AUTO, 1)
-        self._idc.auto_wait()
+        #To avoid timeouts, run it as async but block until complete here.
+        self._async(self._idc.auto_wait)().wait()
 
     def teleport(self, func: Callable) -> Callable:
         def wrapper(*args, **kwargs):

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -453,8 +453,6 @@ class IDARemoteDisassembler(IDADisassembler):
             self.analyze()
         else:
             logger.debug('Skipping autoanalysis.')
-        # Keep a hold of the root remote object to prevent rpyc from prematurely closing on us.
-        self._root = self._bridge.root
         self._running = True
         logger.debug("IDA Disassembler ready!")
 

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -448,11 +448,11 @@ class IDARemoteDisassembler(IDADisassembler):
         self._initialize_bridge()
         # Keep a hold of the root remote object to prevent rpyc from prematurely closing on us.
         self._root = self._bridge.root
+        self._running = True
         if self._analyze:
             self.analyze()
         else:
             logger.debug('Skipping autoanalysis.')
-        self._running = True
         logger.debug("IDA Disassembler ready!")
 
     def stop(self, *exc_info):
@@ -519,6 +519,9 @@ class IDARemoteDisassembler(IDADisassembler):
         """
         Instruct IDA to initiate and wait for auto analysis completion.
         """
+        if not self._running:
+            logger.error('Cannot run IDARemoteDisassembler.analyze() without a connected IDA instance.')
+            return
         logger.debug('Running autoanalysis.')
         self._idc.set_flag(self._idc.INF_GENFLAGS, self._idc.INFFL_AUTO, 1)
         #To avoid timeouts, run it as async but block until complete here.

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -436,8 +436,7 @@ class IDARemoteDisassembler(IDADisassembler):
         finally:
             os.chdir(orig_cwd)
     
-        #For the initial connection, set rpyc_timeout to None so that auto_wait() is allowed to complete.
-        logger.debug(f"Initializing autoanalysis IDA Bridge connection...")
+        logger.debug(f"Initializing IDA Bridge connection...")
         if socket_path:
             self._bridge = self.unix_connect(socket_path)
             # Remember socket path so we can close it later.

--- a/dragodis/ida/ida_server.py
+++ b/dragodis/ida/ida_server.py
@@ -60,6 +60,17 @@ def main():
         socket_path = idc.ARGV[1]
         server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
         server.start()
+    #The first connection is specifically for auto analysis.  This allows setting a timeout of None to allow for very long autoanalysis waittime.
+    #This connection can then have a reasonable timeout value to prevent issues if IDA crashes.
+    if sys.platform == "win32":
+        pipe_name = idc.ARGV[1]
+        stream = NamedPipeStream.create_server(pipe_name)
+        with rpyc.classic.connect_stream(stream) as srv:
+            srv.serve_all()
+    else:
+        socket_path = idc.ARGV[1]
+        server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
+        server.start()
 
     idc.qexit(0)
 

--- a/dragodis/ida/ida_server.py
+++ b/dragodis/ida/ida_server.py
@@ -60,17 +60,6 @@ def main():
         socket_path = idc.ARGV[1]
         server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
         server.start()
-    #The first connection is specifically for auto analysis.  This allows setting a timeout of None to allow for very long autoanalysis waittime.
-    #This connection can then have a reasonable timeout value to prevent issues if IDA crashes.
-    if sys.platform == "win32":
-        pipe_name = idc.ARGV[1]
-        stream = NamedPipeStream.create_server(pipe_name)
-        with rpyc.classic.connect_stream(stream) as srv:
-            srv.serve_all()
-    else:
-        socket_path = idc.ARGV[1]
-        server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
-        server.start()
 
     idc.qexit(0)
 


### PR DESCRIPTION
IDARemoteDisassembler times out when attempting to utilize dragodis on certain files.

IDARemoteDisassembler will timeout if it is used on a file with a larger than normal file loading time or autoanalysis time.
Example 5cc56bb9c934adde84e9e8725199c267d7313f25f83f97b60d0515d57887fe79  (Grandoreiro, although almost any delphi file will probably cause the issue).
This is because the ida_server.py is executed using IDA's -S parameter, which is handled after file loading and autoanalysis are complete.  So if a file takes longer to autoanalyze / load than dragodis takes to run win_connect(), dragodis will not be able to connect to the IDA instance. 

The following should fix the issue:
- in IDARemoteDisassembler, up the retries in both win_connect() and unix_connect() to 20.  This helps handle files with a large amount of sections where file loading may take more time than 10 retries.
- In IDARemoteDisassembler.__init__(), set self._rpyc_config['sync_request_timeout'] = None.  If this isnt done, the timeout will be an rpyc timeout on the idc.auto_wait() call instead of a dragodiserror timeout. 
- In IDARemoteDisassembler.__init__() Add a parameter called should_autoanalyze, which will instruct dragodis not to begin autoanalysis if set to False.  This is useful for running scripts on files with long autoanalysis times where autoanalysis is not a requirement.
- In IDARemoteDisassembler.start(), remove the line "self._idc.auto_wait()".  Replace it with something like the following
`        if self.__should_autoanalyze:
            logger.debug('Running autoanalysis.')
            self._idc.set_flag(self._idc.INF_GENFLAGS, self._idc.INFFL_AUTO, 1)
            self._idc.auto_wait() #For autoanalysis timeouts, hex rays likely needs to be contacted.        
        else:
            logger.debug('Skipping autoanalysis.')`
This code enables autoanalysis and then runs idc.auto_wait() to await autoanalysis results.  
- In IDARemoteDisassembler.start(), add the parameter "-a" to the command arguments list.  This parameter disables auto analysis by default.
- By disabling auto analysis on IDA process start, IDA will only have to load the file before executing the ida_server.py.  This allows the bridge to be properly initialized within the amount of retries that win_connect() allows.  Then, once the bridge is initialized, autoanalysis can be restarted using the line "self._idc.set_flag(self._idc.INF_GENFLAGS, self._idc.INFFL_AUTO, 1)".  idc.auto_wait() can then be called as normal to wait for autoanalysis to complete.
of note: I did try adding a timeout to the autoanalysis feature, but there were issues with the ida_auto.auto_is_ok() function where it would constantly return that autoanalysis isnt running even when it is running.