### PR TITLE
Adds IDA 8.5 Support

### DIFF
--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -214,7 +214,7 @@ class IDARemoteDisassembler(IDADisassembler):
             )
         self._script_path = ida_server.__file__
         self._rpyc_config = dict(self._rpyc_config)
-        if timeout is None or timeout <= 0:
+        if timeout <= 0:
             #Treat zero timeouts or -1 timeouts as infinite.
             timeout = None
         self._rpyc_config["sync_request_timeout"] = timeout

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -210,11 +210,10 @@ class IDARemoteDisassembler(IDADisassembler):
             )
         self._script_path = ida_server.__file__
         self._rpyc_config = dict(self._rpyc_config)
-        if timeout <= 0:
+        if timeout is None or timeout <= 0:
             #Treat zero timeouts or -1 timeouts as infinite.
-            self._rpyc_config["sync_request_timeout"] = None
-        else:
-            self._rpyc_config["sync_request_timeout"] = timeout
+            timeout = None
+        self._rpyc_config["sync_request_timeout"] = timeout
 
         # Determine if 64 bit.
         if is_64_bit is None:

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -214,7 +214,7 @@ class IDARemoteDisassembler(IDADisassembler):
             )
         self._script_path = ida_server.__file__
         self._rpyc_config = dict(self._rpyc_config)
-        if timeout <= 0:
+        if timeout is not None and timeout <= 0:
             #Treat zero timeouts or -1 timeouts as infinite.
             timeout = None
         self._rpyc_config["sync_request_timeout"] = timeout

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -159,9 +159,7 @@ class IDALocalDisassembler(IDADisassembler):
         import ida_entry
         self._ida_entry = ida_entry
         try:
-            """
-            In IDA 8.5 and 9.0 API, ida_struct has been completely removed.
-            """
+            #In IDA 8.5 and 9.0 API, ida_struct has been completely removed.
             import ida_struct
             self._ida_struct = ida_struct
         except ImportError:
@@ -247,10 +245,8 @@ class IDARemoteDisassembler(IDADisassembler):
                 self._ida_exe = os.path.abspath(os.path.join(self._ida_path, filename))
                 break
         else:
-            """
-            IDA 8.5 + No longer has ida64.exe. Search for ida.exe if ida64 isnt present on a 64 bit file.
-            May be useful to eventually do a version check, but I dont think theres a scenario where ida64 is missing and ida.exe is only 32 bit.
-            """
+            #IDA 8.5 + No longer has ida64.exe. Search for ida.exe if ida64 isnt present on a 64 bit file.
+            #May be useful to eventually do a version check, but I dont think theres a scenario where ida64 is missing and ida.exe is only 32 bit.
             if is_64_bit:
                 for filename in os.listdir(self._ida_path):
                     if ida_exe_re32.match(filename):
@@ -360,9 +356,7 @@ class IDARemoteDisassembler(IDADisassembler):
         self._ida_typeinf: ida_typeinf = self._bridge.root.getmodule("ida_typeinf")
         self._ida_entry: ida_entry = self._bridge.root.getmodule("ida_entry")
         try:
-            """
-            IDA 8.5 + no longer has ida_struct.
-            """
+            #IDA 8.5 + no longer has ida_struct.
             self._ida_struct: ida_struct = self._bridge.root.getmodule("ida_struct")
         except ImportError:
             self._ida_struct = None

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -388,7 +388,7 @@ class IDARemoteDisassembler(IDADisassembler):
                 logger.debug(f"Connected to {socket_path}")
                 return link
             except socket.error:
-                time.sleep(1)
+                time.sleep(3)
                 continue
 
         raise DragodisError(f"Could not connect to {socket_path} after {retry} tries.")
@@ -408,7 +408,7 @@ class IDARemoteDisassembler(IDADisassembler):
                 logger.debug(f"Connected to {pipe_name}")
                 return link
             except pywintypes.error:
-                time.sleep(1)
+                time.sleep(3)
                 continue
 
         raise DragodisError(f"Could not connect to {pipe_name} after {retry} tries.")
@@ -443,7 +443,7 @@ class IDARemoteDisassembler(IDADisassembler):
             ]
             if self._processor:
                 command.append(f"-p{self._processor}")
-            #command.append(f'"{self.input_path}"')  # Input file MUST be last!
+            command.append(f'"{self.input_path}"')  # Input file MUST be last!
 
             command = " ".join(command)
             logger.debug(f"Running IDA with command: {command}")
@@ -472,7 +472,6 @@ class IDARemoteDisassembler(IDADisassembler):
         # Keep a hold of the root remote object to prevent rpyc from prematurely closing on us.
         self._root = self._bridge.root
         self._running = True
-        self._idaapi.load_file(self.input_path, '')
         if self._analyze:
             self.analyze()
         else:

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -518,11 +518,11 @@ class IDARemoteDisassembler(IDADisassembler):
     def analyze(self) -> None:
         """
         Instruct IDA to initiate and wait for auto analysis completion.
-        NOTE: This function is likely subject to the timeout value provided in the IDARemoteDisassembler constructor.
         """
         logger.debug('Running autoanalysis.')
         self._idc.set_flag(self._idc.INF_GENFLAGS, self._idc.INFFL_AUTO, 1)
-        self._idc.auto_wait()
+        #To avoid timeouts, run it as async but block until complete here.
+        self._async(self._idc.auto_wait)().wait()
 
     def teleport(self, func: Callable) -> Callable:
         def wrapper(*args, **kwargs):

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -453,8 +453,6 @@ class IDARemoteDisassembler(IDADisassembler):
             self.analyze()
         else:
             logger.debug('Skipping autoanalysis.')
-        # Keep a hold of the root remote object to prevent rpyc from prematurely closing on us.
-        self._root = self._bridge.root
         self._running = True
         logger.debug("IDA Disassembler ready!")
 

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -448,11 +448,11 @@ class IDARemoteDisassembler(IDADisassembler):
         self._initialize_bridge()
         # Keep a hold of the root remote object to prevent rpyc from prematurely closing on us.
         self._root = self._bridge.root
+        self._running = True
         if self._analyze:
             self.analyze()
         else:
             logger.debug('Skipping autoanalysis.')
-        self._running = True
         logger.debug("IDA Disassembler ready!")
 
     def stop(self, *exc_info):
@@ -519,6 +519,9 @@ class IDARemoteDisassembler(IDADisassembler):
         """
         Instruct IDA to initiate and wait for auto analysis completion.
         """
+        if not self._running:
+            logger.error('Cannot run IDARemoteDisassembler.analyze() without a connected IDA instance.')
+            return
         logger.debug('Running autoanalysis.')
         self._idc.set_flag(self._idc.INF_GENFLAGS, self._idc.INFFL_AUTO, 1)
         #To avoid timeouts, run it as async but block until complete here.

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -436,8 +436,7 @@ class IDARemoteDisassembler(IDADisassembler):
         finally:
             os.chdir(orig_cwd)
     
-        #For the initial connection, set rpyc_timeout to None so that auto_wait() is allowed to complete.
-        logger.debug(f"Initializing autoanalysis IDA Bridge connection...")
+        logger.debug(f"Initializing IDA Bridge connection...")
         if socket_path:
             self._bridge = self.unix_connect(socket_path)
             # Remember socket path so we can close it later.

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -443,7 +443,7 @@ class IDARemoteDisassembler(IDADisassembler):
             ]
             if self._processor:
                 command.append(f"-p{self._processor}")
-            command.append(f'"{self.input_path}"')  # Input file MUST be last!
+            #command.append(f'"{self.input_path}"')  # Input file MUST be last!
 
             command = " ".join(command)
             logger.debug(f"Running IDA with command: {command}")
@@ -472,6 +472,7 @@ class IDARemoteDisassembler(IDADisassembler):
         # Keep a hold of the root remote object to prevent rpyc from prematurely closing on us.
         self._root = self._bridge.root
         self._running = True
+        self._idaapi.load_file(self.input_path, '')
         if self._analyze:
             self.analyze()
         else:

--- a/dragodis/ida/disassembler.py
+++ b/dragodis/ida/disassembler.py
@@ -388,7 +388,7 @@ class IDARemoteDisassembler(IDADisassembler):
                 logger.debug(f"Connected to {socket_path}")
                 return link
             except socket.error:
-                time.sleep(3)
+                time.sleep(5)
                 continue
 
         raise DragodisError(f"Could not connect to {socket_path} after {retry} tries.")
@@ -408,7 +408,7 @@ class IDARemoteDisassembler(IDADisassembler):
                 logger.debug(f"Connected to {pipe_name}")
                 return link
             except pywintypes.error:
-                time.sleep(3)
+                time.sleep(5)
                 continue
 
         raise DragodisError(f"Could not connect to {pipe_name} after {retry} tries.")

--- a/dragodis/ida/flat.py
+++ b/dragodis/ida/flat.py
@@ -35,6 +35,10 @@ class IDAFlatAPI(FlatAPI, IDADisassembler):
 
     def _bytes_loaded(self, addr: int, num_bytes: int) -> bool:
         return self._ida_helpers.is_loaded(addr, num_bytes)
+    
+    @property
+    def ida_version(self) -> int:
+        return self._idaapi.IDA_SDK_VERSION
 
     @property
     def processor_name(self) -> str:

--- a/dragodis/ida/flat.py
+++ b/dragodis/ida/flat.py
@@ -145,7 +145,7 @@ class IDAFlatAPI(FlatAPI, IDADisassembler):
             if self.ida_version < 850:
                 flag = self._ida_search.SEARCH_DOWN
             else:
-                flag = self._ida_search.BIN_SEARCH_BACKWARD | self._ida_search.BIN_SEARCH_NOSHOW
+                flag = self._ida_bytes.BIN_SEARCH_BACKWARD | self._ida_bytes.BIN_SEARCH_NOSHOW
             if start is None:
                 start = self.min_address
             if end is None:

--- a/dragodis/ida/function.py
+++ b/dragodis/ida/function.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 import logging
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Union
 
 from dragodis.exceptions import *
 from dragodis.ida.flowchart import IDAFlowchart
-from dragodis.ida.stack import IDAStackFrame
+from dragodis.ida.stack import IDAStackFrame, IDA9StackFrame
 from dragodis.interface import Function, CommentType
 
 if TYPE_CHECKING:
@@ -93,7 +93,16 @@ class IDAFunction(Function):
 
     @property
     def stack_frame(self) -> IDAStackFrame:
-        return IDAStackFrame(self._ida, self._ida._ida_frame.get_frame(self._func_t))
+        if self._ida.ida_version < 850:
+            return IDAStackFrame(self._ida, self._ida._ida_frame.get_frame(self._func_t))
+        else:
+            """
+            The stack frame API was changed a ton in ida 8.5
+            The old version of IDAStackFrame wont work at all, uses entirely different types etc.
+            """
+            frame = self._ida._ida_typeinf.tinfo_t()
+            frame.get_func_frame(self._func_t)
+            return IDA9StackFrame(self._ida, frame)
 
     @property
     def is_library(self) -> bool:

--- a/dragodis/ida/function.py
+++ b/dragodis/ida/function.py
@@ -92,7 +92,7 @@ class IDAFunction(Function):
             return str(decompiled_code)
 
     @property
-    def stack_frame(self) -> Union[IDAStackFrame, IDA9StackFrame]:
+    def stack_frame(self) -> Union[IDAStackFrame]:
         if self._ida.ida_version < 850:
             return IDAStackFrame(self._ida, self._ida._ida_frame.get_frame(self._func_t))
         else:

--- a/dragodis/ida/function.py
+++ b/dragodis/ida/function.py
@@ -96,10 +96,8 @@ class IDAFunction(Function):
         if self._ida.ida_version < 850:
             return IDAStackFrame(self._ida, self._ida._ida_frame.get_frame(self._func_t))
         else:
-            """
-            The stack frame API was changed a ton in ida 8.5
-            The old version of IDAStackFrame wont work at all, uses entirely different types etc.
-            """
+            #The stack frame API was changed a ton in ida 8.5
+            #The old version of IDAStackFrame wont work at all, uses entirely different types etc.
             frame = self._ida._ida_typeinf.tinfo_t()
             frame.get_func_frame(self._func_t)
             return IDA9StackFrame(self._ida, frame)

--- a/dragodis/ida/function.py
+++ b/dragodis/ida/function.py
@@ -92,7 +92,7 @@ class IDAFunction(Function):
             return str(decompiled_code)
 
     @property
-    def stack_frame(self) -> Union[IDAStackFrame]:
+    def stack_frame(self) -> IDAStackFrame:
         if self._ida.ida_version < 850:
             return IDAStackFrame(self._ida, self._ida._ida_frame.get_frame(self._func_t))
         else:

--- a/dragodis/ida/function.py
+++ b/dragodis/ida/function.py
@@ -92,7 +92,7 @@ class IDAFunction(Function):
             return str(decompiled_code)
 
     @property
-    def stack_frame(self) -> IDAStackFrame:
+    def stack_frame(self) -> Union[IDAStackFrame, IDA9StackFrame]:
         if self._ida.ida_version < 850:
             return IDAStackFrame(self._ida, self._ida._ida_frame.get_frame(self._func_t))
         else:

--- a/dragodis/ida/ida_server.py
+++ b/dragodis/ida/ida_server.py
@@ -60,6 +60,17 @@ def main():
         socket_path = idc.ARGV[1]
         server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
         server.start()
+    #The first connection is specifically for auto analysis.  This allows setting a timeout of None to allow for very long autoanalysis waittime.
+    #This connection can then have a reasonable timeout value to prevent issues if IDA crashes.
+    if sys.platform == "win32":
+        pipe_name = idc.ARGV[1]
+        stream = NamedPipeStream.create_server(pipe_name)
+        with rpyc.classic.connect_stream(stream) as srv:
+            srv.serve_all()
+    else:
+        socket_path = idc.ARGV[1]
+        server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
+        server.start()
 
     idc.qexit(0)
 

--- a/dragodis/ida/ida_server.py
+++ b/dragodis/ida/ida_server.py
@@ -60,17 +60,6 @@ def main():
         socket_path = idc.ARGV[1]
         server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
         server.start()
-    #The first connection is specifically for auto analysis.  This allows setting a timeout of None to allow for very long autoanalysis waittime.
-    #This connection can then have a reasonable timeout value to prevent issues if IDA crashes.
-    if sys.platform == "win32":
-        pipe_name = idc.ARGV[1]
-        stream = NamedPipeStream.create_server(pipe_name)
-        with rpyc.classic.connect_stream(stream) as srv:
-            srv.serve_all()
-    else:
-        socket_path = idc.ARGV[1]
-        server = OneShotServer(SlaveService, socket_path=socket_path, auto_register=False)
-        server.start()
 
     idc.qexit(0)
 

--- a/dragodis/ida/operand.py
+++ b/dragodis/ida/operand.py
@@ -15,7 +15,6 @@ from dragodis.interface.types import ARMShiftType
 
 if TYPE_CHECKING:
     import ida_ua
-    import ida_typeinf
     from dragodis.ida.flat import IDAFlatAPI
     from dragodis.ida.instruction import IDAInstruction
 

--- a/dragodis/ida/operand.py
+++ b/dragodis/ida/operand.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING, Union, Tuple
 
 from dragodis.exceptions import NotExistError
-from dragodis.ida.stack import IDAStackVariable, IDAStackFrame
+from dragodis.ida.stack import IDAStackVariable, IDAStackFrame, IDA9StackFrame, IDA9StackVariable
 from dragodis.ida.variable import IDAVariable
 from dragodis.interface import Phrase
 from dragodis.interface.operand import Operand, ARMOperand, x86Operand, OperandType
@@ -15,6 +15,7 @@ from dragodis.interface.types import ARMShiftType
 
 if TYPE_CHECKING:
     import ida_ua
+    import ida_typeinf
     from dragodis.ida.flat import IDAFlatAPI
     from dragodis.ida.instruction import IDAInstruction
 
@@ -112,13 +113,28 @@ class IDAOperand(Operand):
         if isinstance(value, Phrase):
             offset = value.offset
             if isinstance(offset, int):
-                stack_var = self._ida._ida_frame.get_stkvar(self.instruction._insn_t, self._op_t, value.offset)
-                if stack_var:
-                    member, _ = stack_var
+                if self._ida.ida_version < 850:
+                    stack_var = self._ida._ida_frame.get_stkvar(self.instruction._insn_t, self._op_t, value.offset)
+                    if stack_var:
+                        member, _ = stack_var
+                        func_t = self._ida._ida_funcs.get_func(self.address)
+                        frame = self._ida._ida_frame.get_frame(func_t)
+                        frame = IDAStackFrame(self._ida, frame)
+                        return IDAStackVariable(self._ida, frame, member)
+                else:
+                    """
+                    Stack API was changed a ton in IDA 8.5
+                    """
                     func_t = self._ida._ida_funcs.get_func(self.address)
-                    frame = self._ida._ida_frame.get_frame(func_t)
-                    frame = IDAStackFrame(self._ida, frame)
-                    return IDAStackVariable(self._ida, frame, member)
+                    tinfo = self._ida._ida_typeinf.tinfo_t()
+                    tinfo.get_func_frame(func_t)
+                    status = tinfo.get_stkvar(self.instruction._insn_t, self._op_t, value.offset)
+                    if status != -1:
+                        status, stack_var = tinfo.get_udm(status)
+                        if status != -1:
+                            frame = IDA9StackFrame(self._ida, tinfo)
+                            return IDA9StackVariable(self._ida, frame, stack_var)
+
 
         elif isinstance(value, int):  # memory or immediate
             try:

--- a/dragodis/ida/operand.py
+++ b/dragodis/ida/operand.py
@@ -122,9 +122,7 @@ class IDAOperand(Operand):
                         frame = IDAStackFrame(self._ida, frame)
                         return IDAStackVariable(self._ida, frame, member)
                 else:
-                    """
-                    Stack API was changed a ton in IDA 8.5
-                    """
+                    #Stack API was changed a ton in IDA 8.5
                     func_t = self._ida._ida_funcs.get_func(self.address)
                     tinfo = self._ida._ida_typeinf.tinfo_t()
                     tinfo.get_func_frame(func_t)

--- a/dragodis/ida/stack.py
+++ b/dragodis/ida/stack.py
@@ -10,55 +10,6 @@ if TYPE_CHECKING:
     import ida_struct
     import ida_typeinf
 
-class IDA9StackFrame(StackFrame):
-    """
-    This class is equivalent to IDAStackFrame except it contains API changes that allow it to work on
-    IDA 8.5 and 9.0 + only.
-    """
-
-    def __init__(self, ida: IDAFlatAPI, frame: "ida_typeinf.tinfo_t"):
-        self._ida = ida
-        self._frame = frame
-        # Obtain the base of the stack by obtaining the location of the return address.
-        func = self._ida._ida_funcs.get_func(
-            frame.get_frame_func()
-        )
-        self._base_offset = self._ida._ida_frame.frame_off_retaddr(func)
-        self._retsize = self._ida._ida_frame.get_frame_retsize(func)
-
-    def __eq__(self, other):
-        return self is other or self._frame.get_tid() == other._frame.get_tid()
-
-    def __getitem__(self, name_or_offset: Union[str, int]) -> IDA9StackVariable:
-        if isinstance(name_or_offset, int):
-            offset = name_or_offset + self._base_offset
-            status, member = self._frame.get_udm_by_offset(offset)
-        elif isinstance(name_or_offset, str):
-            name = name_or_offset
-            status, member = self._frame.get_udm(name)
-        else:
-            raise TypeError(f"Must be str or int, got {type(name_or_offset)}")
-        if status == -1:
-            raise KeyError(f"Unable to find stack variable from: {name_or_offset}")
-        return IDA9StackVariable(self._ida, self, member)
-
-    def __delitem__(self, name_or_offset: Union[str, int]):
-        variable = self[name_or_offset]
-        self._frame.del_udms(variable._member_index, variable._member_index)
-
-    def __iter__(self) -> Iterable[IDA9StackVariable]:
-        for member in self._frame.iter_udt():
-            variable = IDA9StackVariable(self._ida, self, member)
-            # Ignore the hidden " s" and " r" variables.
-            # TODO: Determine meaning behind these.
-            if variable.name not in (" s", " r"):
-                yield variable
-
-    def __len__(self) -> int:
-        # - 1 for the " s" hidden member and - 1 if there would be a " r" hidden return
-        # variable as well.
-        return self._frame.get_udt_nmembers() - 1 - (1 if self._retsize else 0)
-
 class IDAStackFrame(StackFrame):
 
     def __init__(self, ida: IDAFlatAPI, frame: "ida_struct.struc_t"):
@@ -103,3 +54,52 @@ class IDAStackFrame(StackFrame):
         # - 1 for the " s" hidden member and - 1 if there would be a " r" hidden return
         # variable as well.
         return self._frame.memqty - 1 - (1 if self._retsize else 0)
+
+class IDA9StackFrame(IDAStackFrame):
+    """
+    This class is equivalent to IDAStackFrame except it contains API changes that allow it to work on
+    IDA 8.5 and 9.0 + only.
+    """
+
+    def __init__(self, ida: IDAFlatAPI, frame: "ida_typeinf.tinfo_t"):
+        self._ida = ida
+        self._frame = frame
+        # Obtain the base of the stack by obtaining the location of the return address.
+        func = self._ida._ida_funcs.get_func(
+            frame.get_frame_func()
+        )
+        self._base_offset = self._ida._ida_frame.frame_off_retaddr(func)
+        self._retsize = self._ida._ida_frame.get_frame_retsize(func)
+
+    def __eq__(self, other):
+        return self is other or self._frame.get_tid() == other._frame.get_tid()
+
+    def __getitem__(self, name_or_offset: Union[str, int]) -> IDAStackVariable:
+        if isinstance(name_or_offset, int):
+            offset = name_or_offset + self._base_offset
+            status, member = self._frame.get_udm_by_offset(offset)
+        elif isinstance(name_or_offset, str):
+            name = name_or_offset
+            status, member = self._frame.get_udm(name)
+        else:
+            raise TypeError(f"Must be str or int, got {type(name_or_offset)}")
+        if status == -1:
+            raise KeyError(f"Unable to find stack variable from: {name_or_offset}")
+        return IDA9StackVariable(self._ida, self, member)
+
+    def __delitem__(self, name_or_offset: Union[str, int]):
+        variable = self[name_or_offset]
+        self._frame.del_udms(variable._member_index, variable._member_index)
+
+    def __iter__(self) -> Iterable[IDAStackVariable]:
+        for member in self._frame.iter_udt():
+            variable = IDA9StackVariable(self._ida, self, member)
+            # Ignore the hidden " s" and " r" variables.
+            # TODO: Determine meaning behind these.
+            if variable.name not in (" s", " r"):
+                yield variable
+
+    def __len__(self) -> int:
+        # - 1 for the " s" hidden member and - 1 if there would be a " r" hidden return
+        # variable as well.
+        return self._frame.get_udt_nmembers() - 1 - (1 if self._retsize else 0)

--- a/dragodis/ida/stack.py
+++ b/dragodis/ida/stack.py
@@ -2,13 +2,62 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Iterable, Union
 
-from dragodis.ida.variable import IDAStackVariable
+from dragodis.ida.variable import IDAStackVariable, IDA9StackVariable
 from dragodis.interface.stack import StackFrame
 
 if TYPE_CHECKING:
     from dragodis.ida.flat import IDAFlatAPI
     import ida_struct
+    import ida_typeinf
 
+class IDA9StackFrame(StackFrame):
+    """
+    This class is equivalent to IDAStackFrame except it contains API changes that allow it to work on
+    IDA 8.5 and 9.0 + only.
+    """
+
+    def __init__(self, ida: IDAFlatAPI, frame: "ida_typeinf.tinfo_t"):
+        self._ida = ida
+        self._frame = frame
+        # Obtain the base of the stack by obtaining the location of the return address.
+        func = self._ida._ida_funcs.get_func(
+            frame.get_frame_func()
+        )
+        self._base_offset = self._ida._ida_frame.frame_off_retaddr(func)
+        self._retsize = self._ida._ida_frame.get_frame_retsize(func)
+
+    def __eq__(self, other):
+        return self is other or self._frame.get_tid() == other._frame.get_tid()
+
+    def __getitem__(self, name_or_offset: Union[str, int]) -> IDA9StackVariable:
+        if isinstance(name_or_offset, int):
+            offset = name_or_offset + self._base_offset
+            status, member = self._frame.get_udm_by_offset(offset)
+        elif isinstance(name_or_offset, str):
+            name = name_or_offset
+            status, member = self._frame.get_udm(name)
+        else:
+            raise TypeError(f"Must be str or int, got {type(name_or_offset)}")
+        if status == -1:
+            raise KeyError(f"Unable to find stack variable from: {name_or_offset}")
+        return IDA9StackVariable(self._ida, self, member)
+
+    def __delitem__(self, name_or_offset: Union[str, int]):
+        variable = self[name_or_offset]
+        self._frame.del_udms(variable._member_index, variable._member_index)
+
+    def __iter__(self) -> Iterable[IDA9StackVariable]:
+        for member in self._frame.iter_udt():
+            variable = IDA9StackVariable(self._ida, self, member)
+            # Ignore the hidden " s" and " r" variables.
+            # TODO: Determine meaning behind these.
+            if variable.name not in (" s", " r"):
+                yield variable
+
+    def __len__(self) -> int:
+        # - 1 for the " s" hidden member and - 1 if there would be a " r" hidden return
+        # variable as well.
+        return self._frame.get_udt_nmembers() - 1 - (1 if self._retsize else 0)
 
 class IDAStackFrame(StackFrame):
 

--- a/dragodis/ida/variable.py
+++ b/dragodis/ida/variable.py
@@ -103,7 +103,7 @@ class IDA9StackVariable(IDAStackVariable):
     @property
     def data_type(self) -> IDADataType:
         tif = self._ida._ida_typeinf.tinfo_t()
-        success = self._ida._ida_typeinf.guess_tinfo(tif, self._frame.get_udm_tid(self._member_index))
+        success = self._ida._ida_typeinf.guess_tinfo(tif, self._frame._frame.get_udm_tid(self._member_index))
         if not success:
             raise RuntimeError("Unexpected error getting type information.")
         return IDADataType(self._ida, tif)  #, self._member.flag & self._ida._idc.DT_TYPE)

--- a/dragodis/ida/variable.py
+++ b/dragodis/ida/variable.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from dragodis.ida.flat import IDAFlatAPI
-    from dragodis.ida.stack import IDAStackFrame, IDA9StackFrame
+    from dragodis.ida.stack import IDAStackFrame
     import ida_struct
+    import ida_typeinf
 
 
 class IDAGlobalVariable(GlobalVariable):
@@ -36,48 +37,6 @@ class IDAGlobalVariable(GlobalVariable):
     @property
     def data_type(self) -> IDADataType:
         return IDADataType(self._ida, address=self._address)
-    
-class IDA9StackVariable(StackVariable):
-
-    """
-    This class is equivalent to IDAStackVariable
-    Except it contains API changes for IDA 8.5 / 9.0 +
-    """
-
-    def __init__(self, ida: IDAFlatAPI, frame: IDA9StackFrame, member: "ida_typeinf.udm_t"):
-        self._ida = ida
-        self._frame = frame
-        self._member = member
-        self._member_index = frame._frame.find_udm(self._member, self._ida._ida_typeinf.STRMEM_OFFSET)
-        assert self._member_index != -1
-
-    def __eq__(self, other: "IDAVariable") -> bool:
-        return self._frame == other._frame and self._member.offset == other._member.offset
-
-    @property
-    def stack_offset(self) -> int:
-        return (self._member.offset // 8 ) - self._frame._base_offset
-
-    @property
-    def name(self) -> str:
-        return self._member.name or ""
-
-    @name.setter
-    def name(self, new_name: str):
-        self._frame.rename_udm(self._member_index, new_name, 0)
-
-    @property
-    def data_type(self) -> IDADataType:
-        tif = self._ida._ida_typeinf.tinfo_t()
-        success = self._ida._ida_typeinf.guess_tinfo(tif, self._frame.get_udm_tid(self._member_index))
-        if not success:
-            raise RuntimeError("Unexpected error getting type information.")
-        return IDADataType(self._ida, tif)  #, self._member.flag & self._ida._idc.DT_TYPE)
-
-    @property
-    def size(self) -> int:
-        return self._member.size
-
 
 class IDAStackVariable(StackVariable):
 
@@ -112,6 +71,46 @@ class IDAStackVariable(StackVariable):
     @property
     def size(self) -> int:
         return self._ida._ida_struct.get_member_size(self._member)
+    
+class IDA9StackVariable(IDAStackVariable):
+
+    """
+    This class is equivalent to IDAStackVariable
+    Except it contains API changes for IDA 8.5 / 9.0 +
+    """
+
+    def __init__(self, ida: IDAFlatAPI, frame: IDAStackFrame, member: "ida_typeinf.udm_t"):
+        self._ida = ida
+        self._frame = frame
+        self._member = member
+        self._member_index = frame._frame.find_udm(self._member, self._ida._ida_typeinf.STRMEM_OFFSET)
+
+    def __eq__(self, other: "IDAVariable") -> bool:
+        return self._frame == other._frame and self._member.offset == other._member.offset
+
+    @property
+    def stack_offset(self) -> int:
+        return (self._member.offset // 8 ) - self._frame._base_offset
+
+    @property
+    def name(self) -> str:
+        return self._member.name or ""
+
+    @name.setter
+    def name(self, new_name: str):
+        self._frame.rename_udm(self._member_index, new_name, 0)
+
+    @property
+    def data_type(self) -> IDADataType:
+        tif = self._ida._ida_typeinf.tinfo_t()
+        success = self._ida._ida_typeinf.guess_tinfo(tif, self._frame.get_udm_tid(self._member_index))
+        if not success:
+            raise RuntimeError("Unexpected error getting type information.")
+        return IDADataType(self._ida, tif)  #, self._member.flag & self._ida._idc.DT_TYPE)
+
+    @property
+    def size(self) -> int:
+        return self._member.size
 
 
-IDAVariable = Union[IDAGlobalVariable, IDAStackVariable, IDA9StackVariable]
+IDAVariable = Union[IDAGlobalVariable, IDAStackVariable]


### PR DESCRIPTION
- Makes a couple changes to allow support for IDA 8.5 (And probably 9.0 too, but untested).
- There were major changes relating to how ida's stack api works - including the complete removal of ida_structs.  IDA9StackVariable and IDA9StackFrame add support for these changes.  
- Defaults back to ida.exe if ida64.exe cannot be found for a 64 bit sample (IDA 8.5+ removes ida64.exe completely)

Ive been playing around with this for a little bit when I realized IDA 8.5 made major compatibility changes that broke dragodis.  It works well with with the dragodis based parsers I have (some including usage of Rugosa as well), however more testing may be needed.  Let me know if anyone has any suggestions.  Thank you!