### PR TITLE
Allow set_bytes to work if the segment is writable or can be initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 
 ## [Unreleased]
-- Update `set_bytes` to attempt writing to an uninitialized address if:
-  - In IDA, the address is in a writeable segment
-  - In Ghidra, the address can be initialized
+- In IDA, always attempt to `set_bytes`
+- For Ghidra, if an address is uninitialized when `set_bytes` is called, attempt to initialize the address if `settings.ghidra.initialize_on_write` is `True`
 
 
 ## [1.2.0] - 2026-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## [Unreleased]
-- In IDA, always attempt to `set_bytes`
+- In IDA, check if the address is initialized or is in a valid segment to `set_bytes`
 - For Ghidra, if an address is uninitialized when `set_bytes` is called, attempt to initialize the address if `settings.ghidra.initialize_on_write` is `True`
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## [Unreleased]
+- Update `set_bytes` to attempt writing to an uninitialized address if:
+  - In IDA, the address is in a writeable segment
+  - In Ghidra, the address can be initialized
+
+
 ## [1.2.0] - 2026-05-01
 - Tested and updated for IDA 8.5 and 9.1
 - Tested on Ghidra 11.1.1

--- a/src/dragodis/config/settings.toml
+++ b/src/dragodis/config/settings.toml
@@ -34,6 +34,8 @@ analyze = true
 #   (e.g. { project_name = "MyProject", project_location = "/home/bob/ghidra_projects" })
 # https://pypi.org/project/pyghidra/
 config = {}
+# Determines if an attempt should be made to initialize an address block if it is uninitialized on write request
+initialize_on_write = true
 
 
 [vivisect]

--- a/src/dragodis/ghidra/flat.py
+++ b/src/dragodis/ghidra/flat.py
@@ -11,6 +11,7 @@ from dragodis.interface.flat import FlatAPI, MISSING
 from dragodis.interface.reference import ReferenceType
 from dragodis.interface.types import CompilerType
 from dragodis.exceptions import NotExistError, UnsupportedError
+from dragodis.config import settings
 from .data_type import GhidraDataType
 from .disassembler import GhidraDisassembler, GhidraLocalDisassembler, GhidraRemoteDisassembler
 from .function import GhidraFunction
@@ -193,12 +194,15 @@ class GhidraFlatAPI(FlatAPI, GhidraDisassembler):
         try:
             memory.setBytes(address, data)
         except MemoryAccessException as e:
-            # If setting bytes fails, attempt to initialize the memory block
-            try:
-                block = memory.getBlock(address)
-                memory.convertToInitialized(block, 0)
-                memory.setBytes(address, data)
-            except MemoryAccessException as e:
+            if settings.ghidra.initialize_on_write:
+                # If setting bytes fails, attempt to initialize the memory block
+                try:
+                    block = memory.getBlock(address)
+                    memory.convertToInitialized(block, 0)
+                    memory.setBytes(address, data)
+                except MemoryAccessException as e:
+                    raise NotExistError(f"Cannot set bytes at {hex(addr)}: {e}")
+            else:
                 raise NotExistError(f"Cannot set bytes at {hex(addr)}: {e}")
 
     def find_bytes(self, pattern: bytes, start: int = None, end: int = None, reverse=False) -> int:

--- a/src/dragodis/ghidra/flat.py
+++ b/src/dragodis/ghidra/flat.py
@@ -186,10 +186,7 @@ class GhidraFlatAPI(FlatAPI, GhidraDisassembler):
     def set_bytes(self, addr: int, data: bytes):
         from ghidra.program.model.mem import MemoryAccessException
         address = self._to_addr(addr)
-        try:
-            memory = self._program.getMemory()
-        except MemoryAccessException as e:
-            raise NotExistError(f"Cannot set bytes at {hex(addr)}: {e}")
+        memory = self._program.getMemory()
 
         try:
             memory.setBytes(address, data)

--- a/src/dragodis/ghidra/flat.py
+++ b/src/dragodis/ghidra/flat.py
@@ -184,11 +184,22 @@ class GhidraFlatAPI(FlatAPI, GhidraDisassembler):
 
     def set_bytes(self, addr: int, data: bytes):
         from ghidra.program.model.mem import MemoryAccessException
+        address = self._to_addr(addr)
         try:
             memory = self._program.getMemory()
-            memory.setBytes(self._to_addr(addr), data)
         except MemoryAccessException as e:
             raise NotExistError(f"Cannot set bytes at {hex(addr)}: {e}")
+
+        try:
+            memory.setBytes(address, data)
+        except MemoryAccessException as e:
+            # If setting bytes fails, attempt to initialize the memory block
+            try:
+                block = memory.getBlock(address)
+                memory.convertToInitialized(block, 0)
+                memory.setBytes(address, data)
+            except MemoryAccessException as e:
+                raise NotExistError(f"Cannot set bytes at {hex(addr)}: {e}")
 
     def find_bytes(self, pattern: bytes, start: int = None, end: int = None, reverse=False) -> int:
         if start is not None:

--- a/src/dragodis/ida/flat.py
+++ b/src/dragodis/ida/flat.py
@@ -173,13 +173,7 @@ class IDAFlatAPI(FlatAPI, IDADisassembler):
             raise ValueError(f"Could not override compiler to {compiler}")
         self._ida_auto.auto_wait()
 
-    def _check_writable(self, addr: int) -> bool:
-        return bool((segment := self.get_segment(addr)) and segment.permissions & SegmentPermission.write)
-
     def set_bytes(self, addr: int, data: bytes):
-        # Check if we would be writing to an uninitialized section that is not writable
-        if not (self._ida_helpers.is_loaded(addr, len(data)) or self._check_writable(addr)):
-            raise NotExistError(f"Unable to write to address not fully initialized or writeable: 0x{addr:08x}")
         self._ida_bytes.patch_bytes(addr, data)
 
     def find_bytes(self, pattern: bytes, start: int = None, end: int = None, reverse=False) -> int:

--- a/src/dragodis/ida/flat.py
+++ b/src/dragodis/ida/flat.py
@@ -174,7 +174,13 @@ class IDAFlatAPI(FlatAPI, IDADisassembler):
         self._ida_auto.auto_wait()
 
     def set_bytes(self, addr: int, data: bytes):
-        self._ida_bytes.patch_bytes(addr, data)
+        # Check if we would be writing to an uninitialized section that is not in the binary
+        if self._ida_helpers.is_loaded(addr, len(data)) or self.get_segment(addr):
+            self._ida_bytes.patch_bytes(addr, data)
+        else:
+            raise NotExistError(
+                f"Unable to write to address not fully initialized or in a segment of the binary: 0x{addr:08x}"
+            )
 
     def find_bytes(self, pattern: bytes, start: int = None, end: int = None, reverse=False) -> int:
         # Convert bytes pattern into hex separated by space format that IDA likes.

--- a/src/dragodis/ida/flat.py
+++ b/src/dragodis/ida/flat.py
@@ -23,7 +23,7 @@ from .segment import IDASegment
 from .string import IDAString
 from .symbol import IDAImport, IDAExport
 from .variable import IDAGlobalVariable
-from ..interface import CompilerType, ReferenceType
+from ..interface import CompilerType, ReferenceType, SegmentPermission
 from ..utils import genproperty
 
 cache = lru_cache(maxsize=1024)
@@ -173,10 +173,13 @@ class IDAFlatAPI(FlatAPI, IDADisassembler):
             raise ValueError(f"Could not override compiler to {compiler}")
         self._ida_auto.auto_wait()
 
+    def _check_writable(self, addr: int) -> bool:
+        return bool((segment := self.get_segment(addr)) and segment.permissions & SegmentPermission.write)
+
     def set_bytes(self, addr: int, data: bytes):
-        # Check if we would be writing to an uninitialized section.
-        if not self._ida_helpers.is_loaded(addr, len(data)):
-            raise NotExistError(f"Unable to write to address not fully initialized: 0x{addr:08x}")
+        # Check if we would be writing to an uninitialized section that is not writable
+        if not (self._ida_helpers.is_loaded(addr, len(data)) or self._check_writable(addr)):
+            raise NotExistError(f"Unable to write to address not fully initialized or writeable: 0x{addr:08x}")
         self._ida_bytes.patch_bytes(addr, data)
 
     def find_bytes(self, pattern: bytes, start: int = None, end: int = None, reverse=False) -> int:

--- a/src/dragodis/ida/flat.py
+++ b/src/dragodis/ida/flat.py
@@ -23,7 +23,7 @@ from .segment import IDASegment
 from .string import IDAString
 from .symbol import IDAImport, IDAExport
 from .variable import IDAGlobalVariable
-from ..interface import CompilerType, ReferenceType, SegmentPermission
+from ..interface import CompilerType, ReferenceType
 from ..utils import genproperty
 
 cache = lru_cache(maxsize=1024)


### PR DESCRIPTION
Instead of having `set_bytes` fail if the address being accessed is not initalized:
* In IDA, check if the address is in a writable segment and allow the attempt if it is
* In Ghidra, attempt to initialize the address