### PR TITLE
Use get_ and set_ functions for cc access in func_type_data objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [Unreleased]
 - In IDA, check if the address is initialized or is in a valid segment to `set_bytes`
 - For Ghidra, if an address is uninitialized when `set_bytes` is called, attempt to initialize the address if `settings.ghidra.initialize_on_write` is `True`
-
+- In IDA >= 9.2, use `get_cc` and `set_cc` functions since `cc` property is not exposed for `_func_type_data` objects
 
 ## [1.2.0] - 2026-05-01
 - Tested and updated for IDA 8.5 and 9.1

--- a/src/dragodis/ida/function_signature.py
+++ b/src/dragodis/ida/function_signature.py
@@ -78,7 +78,11 @@ class IDAFunctionSignature(FunctionSignature):
 
     @property
     def calling_convention(self) -> str:
-        cc = self._func_type_data.cc & self._ida._ida_typeinf.CM_CC_MASK
+        # Available in versions <=9.1
+        if hasattr(self._func_type_data, "cc"):
+            cc = self._func_type_data.cc & self._ida._ida_typeinf.CM_CC_MASK
+        else:
+            cc = self._func_type_data.get_cc() & self._ida._ida_typeinf.CM_CC_MASK
         try:
             return self._cc_map[cc]
         except KeyError:
@@ -94,8 +98,13 @@ class IDAFunctionSignature(FunctionSignature):
         except KeyError:
             raise ValueError(f"Invalid calling convention name: {name}")
         # Set calling convention part of cm_t flags.
-        cc |= self._func_type_data.cc & (self._ida._ida_typeinf.CM_CC_MASK ^ 0xff)
-        self._func_type_data.cc = cc
+        # Available in versions <=9.1
+        if hasattr(self._func_type_data, "cc"):
+            cc |= self._func_type_data.cc & (self._ida._ida_typeinf.CM_CC_MASK ^ 0xff)
+            self._func_type_data.cc = cc
+        else:
+            cc |= self._func_type_data.get_cc() & (self._ida._ida_typeinf.CM_CC_MASK ^ 0xff)
+            self._func_type_data.set_cc(cc)
         self._apply()
         self._parameters = None
 


### PR DESCRIPTION
In IDA 9.2, direct access to a `cc` property was removed for `ida_typeinf.func_type_data_t` objects and replaced with `get_cc` and `set_cc` functions

Add support for IDA 9.2+ while retaining support for <= IDA 9.1